### PR TITLE
Switch GitHub Actions to metalbear-co forks

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -14,19 +14,15 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install latest stable
-        uses: dtolnay/rust-toolchain@stable
+        uses: metalbear-co/setup-rust-toolchain@a8d42d5aa259519dac1faeee20e37c1fb43453a3
         with:
-          targets: ${{ matrix.target }}
           components: rustfmt,clippy
 
       - name: Run rustfmt
         run: cargo fmt --all --check
 
       - name: Run clippy
-        uses: giraffate/clippy-action@v1
-        with:
-          reporter: 'github-pr-check'
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+        run: cargo clippy -- -D warnings
 
       - name: Run tests default
         run: cargo test

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,10 +11,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
-        with:
-            toolchain: stable
-            override: true
-      - uses: katyo/publish-crates@v2
-        with:
-            registry-token: ${{ secrets.CRATES_IO_SECRET }}
+      - uses: metalbear-co/setup-rust-toolchain@a8d42d5aa259519dac1faeee20e37c1fb43453a3
+      - name: Publish to crates.io
+        run: cargo publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_SECRET }}

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -17,10 +17,20 @@ async fn main() -> Result<(), Box<dyn Error>> {
         proxy.set_authorization(Authorization::basic("John Doe", "Agent1234"));
         let connector = HttpConnector::new();
 
-        #[cfg(not(any(feature = "native-tls", feature = "native-tls-vendored", feature = "rustls-tls-webpki-roots", feature = "rustls-tls-native-roots")))]
+        #[cfg(not(any(
+            feature = "native-tls",
+            feature = "native-tls-vendored",
+            feature = "rustls-tls-webpki-roots",
+            feature = "rustls-tls-native-roots"
+        )))]
         let proxy_connector = ProxyConnector::from_proxy_unsecured(connector, proxy);
 
-        #[cfg(any(feature = "native-tls", feature = "native-tls-vendored", feature = "rustls-tls-webpki-roots", feature = "rustls-tls-native-roots"))]
+        #[cfg(any(
+            feature = "native-tls",
+            feature = "native-tls-vendored",
+            feature = "rustls-tls-webpki-roots",
+            feature = "rustls-tls-native-roots"
+        ))]
         let proxy_connector = ProxyConnector::from_proxy(connector, proxy).unwrap();
 
         proxy_connector

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -17,10 +17,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
         proxy.set_authorization(Authorization::basic("John Doe", "Agent1234"));
         let connector = HttpConnector::new();
 
-        #[cfg(not(any(feature = "tls", feature = "rustls-base", feature = "openssl-tls")))]
+        #[cfg(not(any(feature = "native-tls", feature = "native-tls-vendored", feature = "rustls-tls-webpki-roots", feature = "rustls-tls-native-roots")))]
         let proxy_connector = ProxyConnector::from_proxy_unsecured(connector, proxy);
 
-        #[cfg(any(feature = "tls", feature = "rustls-base", feature = "openssl"))]
+        #[cfg(any(feature = "native-tls", feature = "native-tls-vendored", feature = "rustls-tls-webpki-roots", feature = "rustls-tls-native-roots"))]
         let proxy_connector = ProxyConnector::from_proxy(connector, proxy).unwrap();
 
         proxy_connector

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -383,7 +383,7 @@ impl<C> ProxyConnector<C> {
     /// These headers must be appended to the hyper Request for the proxy to work properly.
     /// This is needed only for http requests.
     pub fn http_headers(&self, uri: &Uri) -> Option<&HeaderMap> {
-        if uri.scheme_str().map_or(true, |s| s != "http") {
+        if uri.scheme_str() != Some("http") {
             return None;
         }
 
@@ -528,9 +528,7 @@ fn proxy_dst(dst: &Uri, proxy: &Uri) -> io::Result<Uri> {
 fn extract_user_pass(uri: &Uri) -> Option<(&str, &str)> {
     let authority = uri.authority()?.as_str();
     let (userinfo, _) = authority.rsplit_once('@')?;
-    let mut parts = userinfo.splitn(2, ':');
-    let username = parts.next()?;
-    let password = parts.next()?;
+    let (username, password) = userinfo.split_once(':')?;
     Some((username, password))
 }
 


### PR DESCRIPTION
**Probably nicer to review commit-by-commit.**

## Summary

- Replace `dtolnay/rust-toolchain` and `actions-rs/toolchain` with `metalbear-co/setup-rust-toolchain` (fork of `actions-rust-lang/setup-rust-toolchain`)
- Replace `giraffate/clippy-action` with a plain `cargo clippy -- -D warnings` step (no org fork exists)
- Replace `katyo/publish-crates` with `cargo publish` using `CARGO_REGISTRY_TOKEN` env var (no org fork exists; env var is safer than `--token` CLI arg)

🤖 Generated with [Claude Code](https://claude.com/claude-code)